### PR TITLE
I do some typing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "jekyll-pub",
-    platforms: [.macOS(.v10_15)],
+    platforms: [.macOS(.v13)],
     products: [
         .executable(name: "jekyll-pub", targets: ["jekyll-pub"])
     ],

--- a/Sources/jekyll-pub/Jekyll/JekyllMedia.swift
+++ b/Sources/jekyll-pub/Jekyll/JekyllMedia.swift
@@ -17,15 +17,14 @@ struct JekyllMedia: Decodable {
 struct JekyllMediaResult: Encodable {
     let name: String
     let type: String
-    let siteURL: String
+
+    // Path relative to site root. I'm assuming this is also the path
+    // relative to the web root
+    let relativePath: String
     
-    init(url: URL) {
+    init(url: URL, root: URL) {
         name = url.lastPathComponent
-        let components = url.pathComponents
-        let _files = components.lastIndex(of: "_files")!
-        let pieces = components.dropFirst(_files + 1)
-        siteURL = "/files/" + pieces.joined(separator: "/")
-        
+        relativePath = url.absoluteString.replacing(root.absoluteString, with: "")
         let tag = url.pathExtension
         let cfTypes = UTTypeCreateAllIdentifiersForTag(kUTTagClassFilenameExtension, tag as CFString, nil)?.takeRetainedValue()
         let types = (cfTypes as? Array<String>) ?? []
@@ -37,6 +36,6 @@ struct JekyllMediaResult: Encodable {
         try c.encode(name, forKey: "id")
         try c.encode(name, forKey: "file")
         try c.encode(type, forKey: "type")
-        try c.encode(siteURL, forKey: "url")
+        try c.encode(relativePath, forKey: "url")
     }
 }

--- a/Sources/jekyll-pub/Jekyll/JekyllPost.swift
+++ b/Sources/jekyll-pub/Jekyll/JekyllPost.swift
@@ -8,8 +8,7 @@
 import Foundation
 import Yams
 
-let NoID = "<<NONE>>"
-
+// Formats publish date in front matter when it's written to disk
 let publishDateFormatter: DateFormatter = {
     let df = DateFormatter()
     df.calendar = Calendar(identifier: .gregorian)
@@ -19,7 +18,27 @@ let publishDateFormatter: DateFormatter = {
     return df
 }()
 
-struct JekyllPost {
+// This is an array of increasingly liberal date parsers that should try to
+// hit every edge case of date format that I see in the wild (Jekyll preamble dates
+// are pretty liberal
+let publishDateParsers: [ISO8601DateFormatter] = [ISO8601DateFormatter.Options]([
+    [.withInternetDateTime],
+    [.withSpaceBetweenDateAndTime, .withColonSeparatorInTime, .withTimeZone],
+    [.withSpaceBetweenDateAndTime, .withColonSeparatorInTime, .withTimeZone, .withColonSeparatorInTimeZone],
+    [.withSpaceBetweenDateAndTime, .withColonSeparatorInTime],
+]).flatMap { options in
+    let df = ISO8601DateFormatter()
+    // We _always_ want a full date and time
+    df.formatOptions = options.union([.withFullTime, .withFullDate])
+
+    // Also parse fractional seconds if present
+    let dfFractional = ISO8601DateFormatter()
+    dfFractional.formatOptions = options.union([.withFullTime, .withFullDate, .withFractionalSeconds])
+
+    return [df, dfFractional]
+}
+
+struct JekyllPost: Hashable {
     
     enum Status: String, Codable {
         static var published: Status { .publish }
@@ -36,60 +55,86 @@ struct JekyllPost {
     var body: String
     var status: Status
     var kind: Kind
+    var rootURL: URL
     var fileURL: URL?
-    
+    var slug: String?
+
+    // Treating post as a dict exposes raw front matter for get and set
     subscript(key: String) -> Yams.Node? {
-        get {
-            return yaml.mapping?[key]
-        }
-        set {
-            yaml.mapping?[key] = newValue
-        }
+        get { yaml.mapping?[key] }
+        set { yaml.mapping?[key] = newValue }
     }
     
-    var id: String {
-        get { self["id"]?.string ?? NoID }
-        set { self["id"] = .init(newValue) }
+    // By default ID is relative path to file from site root, front matter can override it.
+    // Setting it puts the override in the front matter.
+    var id: String? {
+        get { self["id"]?.string ?? fileURL?.absoluteString.replacing(rootURL.absoluteString, with: "") }
+        set { self["id"] = newValue.map { .init($0) } }
     }
     
     var tags: Array<String> {
-        get {
-            return self["tags"]?.array().compactMap(\.string) ?? []
-        }
-        set {
-            self["tags"] = .init(newValue.map { .init($0) })
-        }
+        get { self["tags"]?.array().compactMap(\.string) ?? [] }
+        set { self["tags"] = .init(newValue.map { .init($0) }) }
     }
     
-    var title: String {
-        get { self["title"]?.string ?? "New Post" }
-        set { self["title"] = .init(newValue) }
+    var title: String? {
+        get { self["title"]?.string }
+        set { self["title"] = newValue.map { .init($0) } }
     }
-    
+
     var publishedDate: Date? {
         get {
-            guard let pub = self["published"]?.string else { return nil }
-            return publishDateFormatter.date(from: pub)
+            // Look for explicit "published" then "date" keys in the front matter
+            if let pub = self["published"]?.string ?? self["date"]?.string {
+                if let date = publishDateParsers.lazy.compactMap({ $0.date(from: pub) }).first {
+                    return date
+                }
+                // Ideally we should do what jekyll does if it can't parse the date. Whatever that is.
+                assertionFailure("Can't parse date \(pub)")
+                return nil
+            }
+
+            // For published blog posts, if there is no date key, assuming the filename is yyyy-mm-dd-slug
+            if kind == .post && status == .published {
+                guard let path = fileURL?.path else { return nil }
+                let dateFromPath = try! Regex(#"\/(\d{4}\-\d{2}\-\d{2})-[^\/]+$"#)
+                if let result = try? dateFromPath.firstMatch(in: path) {
+                    return slugDateFormatter.date(from: String(result[1].value as! Substring))
+                }
+            }
+
+            // Pages and drafts don't have to have a date
+            return nil
         }
         set {
             if let new = newValue {
                 let str = publishDateFormatter.string(from: new)
-                self["published"] = .init(str)
+                self["date"] = .init(str)
             } else {
-                self["published"] = nil
+                self["date"] = nil
             }
         }
     }
-    
-    init() {
+
+    var editedDate: Date? {
+        get {
+            // mtime off disk, nothing clever
+            guard let fileURL else { return nil }
+            let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+            return attrs?[FileAttributeKey.creationDate] as? Date
+        }
+    }
+
+    init(root: URL) {
+        self.rootURL = root
         self.yaml = [:]
         self.body = ""
         self.fileURL = nil
         self.status = .draft
         self.kind = .post
     }
-    
-    init(url: URL, isPost: Bool, isDraftsFolder: Bool) throws {
+
+    init(url: URL, root: URL, isPost: Bool, isDraftsFolder: Bool) throws {
         let contents = try String(contentsOf: url)
         let nsContents = contents as NSString
         let ymlRegex = try NSRegularExpression(pattern: "^---[\r\n](.*?)---[\r\n]+(.*)$", options: [.dotMatchesLineSeparators, .anchorsMatchLines])
@@ -99,21 +144,28 @@ struct JekyllPost {
         if let match = ymlRegex.firstMatch(in: contents, options: [.anchored], range: NSRange(location: 0, length: nsContents.length)) {
             let extracted = nsContents.substring(with: match.range(at: 1))
             yaml = try Yams.compose(yaml: extracted)
-            
             body = nsContents.substring(with: match.range(at: 2))
         }
         
+        self.rootURL = root
         self.yaml = yaml ?? [:]
         self.body = body ?? contents
         self.status = isDraftsFolder ? .draft : .published
         self.fileURL = url
         self.kind = isPost ? .post : .page
-        if isPost == false {
-            self.id = url.absoluteString
+
+        if let explicitSlug = self["slug"]?.string {
+            // Front matter can specify slug explicitly
+            slug = explicitSlug
+        } else if isPost {
+            // Published post filenames can start yyyy-mm-dd-, the remainder is the slug
+            slug = url.deletingPathExtension().lastPathComponent.replacing(try! Regex(#"^\d{4}\-\d{2}\-\d{2}-"#), with: "")
+        } else {
+            // Slugs for pages are their paths relative to the server root. Kinda weird
+            // but I have no better place to expose path information (maybe categories?)
+            slug = String(url.deletingPathExtension().absoluteString.replacing(root.absoluteString, with: "").trimmingPrefix("/"))
         }
-        if self.id == NoID && isPost == true {
-            self.id = title.slugified()
-        }
+
     }
     
     func content() throws -> String {
@@ -127,11 +179,15 @@ struct JekyllPost {
     }
 }
 
+// Metaweblog representation
+// TODO this should be in MetaWeblog.swift and use a dedicated object,
+// but I can't test it because I have no client - marsedit is the only
+// thing I really care about and it doesn't call any methods in this file.
 extension JekyllPost: Codable {
-    
+
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: AnyCodingKey.self)
-        self.init()
+        self.init(root: URL(string: "")!)
         self.title = try c.decode(String.self, forKey: "title")
         self.body = try c.decode(String.self, forKey: "body")
         if let status = try c.decodeIfPresent(Status.self, forKey: "post_status") {
@@ -152,9 +208,26 @@ extension JekyllPost: Codable {
         try c.encode(["Uncategorized"], forKey: "categories")
         try c.encode(status, forKey: "post_status")
         try c.encode(tags, forKey: "mt_keywords")
+        try c.encode(slug, forKey: "wp_slug")
         if let d = publishedDate {
             try c.encode(d, forKey: "dateCreated")
         }
+        if let d = editedDate {
+            try c.encode(d, forKey: "date_modified")
+        }
     }
     
+}
+
+extension JekyllPost: Comparable {
+    // Sorts most recent post first, unpublished things come first so we always surface
+    // drafts on the first page
+    static func < (lhs: JekyllPost, rhs: JekyllPost) -> Bool {
+        switch (lhs.publishedDate, rhs.publishedDate) {
+        case (nil, nil): return false
+        case (nil, _): return true
+        case (_, nil): return false
+        case (.some(let l), .some(let r)): return l > r
+        }
+    }
 }

--- a/Sources/jekyll-pub/Jekyll/JekyllSite+Media.swift
+++ b/Sources/jekyll-pub/Jekyll/JekyllSite+Media.swift
@@ -16,8 +16,8 @@ extension JekyllSite {
         if let iterator = enumerator {
             for anyURL in iterator {
                 guard let url = anyURL as? URL else { continue }
-                guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else { continue }
-                let media = JekyllMediaResult(url: url)
+                guard (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == false else { continue }
+                let media = JekyllMediaResult(url: url, root: rootFolder)
                 mediaItems.append(media)
             }
         }
@@ -43,7 +43,7 @@ extension JekyllSite {
         }
         
         try media.bits.write(to: url)
-        return JekyllMediaResult(url: url)
+        return JekyllMediaResult(url: url, root: rootFolder)
     }
     
 }

--- a/Sources/jekyll-pub/Jekyll/JekyllSite+Posts.swift
+++ b/Sources/jekyll-pub/Jekyll/JekyllSite+Posts.swift
@@ -7,48 +7,69 @@
 
 import Foundation
 
+// The cache maps unsorted posts -> sorted posts. Fetching posts is about 10% of the total cost
+// of generating a sorted list for me - parsing the dates is much more expensive. So basing the
+// cache on the unsorted state of the disk files lets me _completely_ ignore the tricky "cache
+// invalidation" problems here - if anything changes on disk (we might change it, external editor
+// might change it) the fetched files will be different, and we'll re-sort. This is a big speed
+// improvement over sorting every time we need a post list.
+var sortedAllPostsCache = [[JekyllPost]: [JekyllPost]]()
+
 extension JekyllSite {
     
-    private func posts(in folder: URL, isDrafts: Bool) -> Array<JekyllPost> {
-        let enumerator = FileManager.default.enumerator(at: folder, includingPropertiesForKeys: nil)
+    private func posts(in rootFolder: URL, isDrafts: Bool) -> Array<JekyllPost> {
+        guard let iterator = FileManager.default.enumerator(
+            at: rootFolder,
+            includingPropertiesForKeys: nil
+        ) else { return [] }
+
+        // A post is any file with '_posts' or '_drafts' anywhere in the parent tree of the file
+        let postsFolder = isDrafts ? "_drafts" : "_posts"
         var posts = Array<JekyllPost>()
-        
-        if let iterator = enumerator {
-            for anyURL in iterator {
-                guard let url = anyURL as? URL else { continue }
-                guard let post = try? JekyllPost(url: url, isPost: true, isDraftsFolder: isDrafts) else { continue }
-                posts.append(post)
+        for anyURL in iterator {
+            guard let url = anyURL as? URL else { continue }
+            if url.hasDirectoryPath || !url.pathComponents.contains(postsFolder) {
+                continue
             }
+            guard let post = try? JekyllPost(url: url, root: rootFolder, isPost: true, isDraftsFolder: isDrafts) else { continue }
+            posts.append(post)
         }
         return posts
     }
     
-    func allDrafts() -> Array<JekyllPost> {
-        posts(in: draftsFolder, isDrafts: true)
+    private func allDrafts() -> Array<JekyllPost> {
+        posts(in: rootFolder, isDrafts: true)
     }
     
-    func allPublished() -> Array<JekyllPost> {
-        posts(in: postsFolder, isDrafts: false)
+    private func allPublished() -> Array<JekyllPost> {
+        posts(in: rootFolder, isDrafts: false)
     }
     
-    func allPosts() -> Array<JekyllPost> {
-        return allDrafts() + allPublished() + allPages()
-    }
-    
-    func allPages() -> Array<JekyllPost> {
+    private func allPages() -> Array<JekyllPost> {
         let enumerator = FileManager.default.enumerator(at: site.rootFolder, includingPropertiesForKeys: [.typeIdentifierKey])
         var pages = Array<JekyllPost>()
         
         if let iterator = enumerator {
             for anyURL in iterator {
                 guard let url = anyURL as? URL else { continue }
-                if url.lastPathComponent.hasPrefix("_") { iterator.skipDescendants() }
+                // Skip all subtrees that start with an underscore - this is _posts, _drafts, or some
+                // Jekyll control / config files that aren't content
+                if url.lastPathComponent.hasPrefix("_") {
+                    iterator.skipDescendants()
+                    continue
+                }
+                // Don't look for pages in the assets folder
+                if url == filesFolder {
+                    iterator.skipDescendants()
+                    continue
+                }
+
                 guard let type = (try? url.resourceValues(forKeys: [.typeIdentifierKey]))?.typeIdentifier else { continue }
                 var page: JekyllPost?
                 if UTTypeConformsTo(type as CFString, "public.html" as CFString) {
-                    page = try? JekyllPost(url: url, isPost: false, isDraftsFolder: false)
+                    page = try? JekyllPost(url: url, root: site.rootFolder, isPost: false, isDraftsFolder: false)
                 } else if UTTypeConformsTo(type as CFString, "net.daringfireball.markdown" as CFString) {
-                    page = try? JekyllPost(url: url, isPost: false, isDraftsFolder: false)
+                    page = try? JekyllPost(url: url, root: site.rootFolder, isPost: false, isDraftsFolder: false)
                 }
                 if let p = page { pages.append(p) }
             }
@@ -56,7 +77,22 @@ extension JekyllSite {
         
         return pages
     }
-    
+
+    /// Returns a list of every post and page on the filesystem, sorted with unpublished files
+    /// first (so drafts are at the top of the recents list) followed by reverse publish order.
+    func allPosts() -> Array<JekyllPost> {
+        let all = allDrafts() + allPublished() + allPages()
+        if let cached = sortedAllPostsCache[all] {
+            return cached
+        }
+        // Sanity check - all post urls must be globally distinct
+        assert(Set(all.map { $0.id }).count == all.count)
+        let sorted = all.sorted()
+        // throw away the old cache keys
+        sortedAllPostsCache = [all: sorted]
+        return sorted
+    }
+
     func allTags() -> Array<String> {
         let posts = allPosts()
         let all = Set(posts.flatMap(\.tags))
@@ -68,15 +104,7 @@ extension JekyllSite {
     }
     
     func recentPosts(_ count: Int) -> Array<JekyllPost> {
-        let sorted = allPosts().sorted(by: { p1, p2 -> Bool in
-            switch (p1.publishedDate, p2.publishedDate) {
-                case (nil, nil): return false
-                case (nil, _): return true
-                case (_, nil): return false
-                case (.some(let l), .some(let r)): return l < r
-            }
-        })
-        return sorted.suffix(count)
+        return allPosts().suffix(count)
     }
     
     func deletePost(_ id: String) -> Bool {
@@ -103,45 +131,60 @@ extension JekyllSite {
             filledOut.publishedDate = Date()
         }
         
-        let url = self.url(for: &filledOut, publish: publish)
+        let url = try self.updateFileURL(for: &filledOut)
         let content = try filledOut.content()
+        // Create the parent directory if needed
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
-        
         return filledOut
     }
-    
-    func editPost(_ post: JekyllPost, publish: Bool) throws -> Bool {
-        let currentPost = try getPost(post.id)
-        
-        if currentPost.status != post.status {
-            _ = deletePost(post.id)
+
+    @discardableResult
+    func editPost(_ post: JekyllPost, publish: Bool) throws -> JekyllPost {
+        let id = try post.id ?! CocoaError(CocoaError.fileNoSuchFile)
+        let oldFileUrl = try getPost(id).fileURL
+        let created = try newPost(post, publish: publish)
+
+        // Updating the post might have change the filename on disk (changed date,
+        // changed slug, published post) - remove the old file in that case
+        if let oldFileUrl, created.fileURL != oldFileUrl {
+            try? FileManager.default.removeItem(at: oldFileUrl)
         }
-        _ = try newPost(post, publish: publish)
-        
-        return true
+
+        return created
     }
     
-    private func url(for post: inout JekyllPost, publish: Bool) -> URL {
-        if let u = post.fileURL { return u }
-        
-        if post.kind == .page {
-            if let u = URL(string: post.id) {
-                post.fileURL = u
-                return u
+    // Update the fileURL of the post to be the "desired" fileURL given the published status,
+    // kind, date, and slug.
+    //
+    // We're not making any effort here to retain the existing filename in the case that there's
+    // a page with a "slug" propery in the front matter. Maybe we should.
+    private func updateFileURL(for post: inout JekyllPost) throws -> URL {
+        let slug = post.slug ?? post.title?.slugified() ?? "post"
+
+        let url: URL
+        switch post.kind {
+        case .page:
+            url = try URL(string: "\(slug).md", relativeTo: rootFolder) ?! CocoaError(CocoaError.fileNoSuchFile) // TOOD error
+        case .post:
+            let publish = post.status == .publish
+            var baseName = slug
+            if let pubDate = post.publishedDate, publish {
+                baseName = slugDateFormatter.string(from: pubDate) + "-" + slug
             }
+            url = rootFolder.appendingPathComponent(publish ? "_posts" : "_drafts").appendingPathComponent("\(baseName).md")
         }
-        
-        let title = post.title
-        let slug = title.slugified()
-        
-        var baseName = slug
-        if let pubDate = post.publishedDate {
-            post.id = slug
-            baseName = slugDateFormatter.string(from: pubDate) + "-" + slug
-        }
-        
-        let url = (publish ? postsFolder : draftsFolder).appendingPathComponent("\(baseName).md")
+
+        // Preserve the old post ID in the front matter if the filename changes and we were
+        // using the filename as the ID, because MarsEdit can't handle the ID changing on save.
+        // TODO this is kinda weird because it's the filename, so it preserves the first
+        // published slug and date (or _drafts) of the file. MD5 might be better just so it's opaque?
+        let oldID = post.id
         post.fileURL = url
+        if let oldID, post.id != oldID {
+            post.id = .init(oldID)
+        }
+
         return url
     }
 }

--- a/Sources/jekyll-pub/Jekyll/JekyllSite.swift
+++ b/Sources/jekyll-pub/Jekyll/JekyllSite.swift
@@ -8,16 +8,25 @@
 import Foundation
 
 struct JekyllSite {
+    // Serve XMLRPC on this port
+    let port: UInt16 = 9080
+
+    // Root of the Jekyll site on disk
     let rootFolder: URL
-    let postsFolder: URL
+
+    // Not the only place files can be, but the contents of this folder will be exposed
+    // from the getMediaLibrary endpoint, and binary uploads will go here.
     let filesFolder: URL
-    let draftsFolder: URL
-    
+
     init(siteFolder: Path) {
         rootFolder = siteFolder.fileURL
-        postsFolder = siteFolder.fileURL.appendingPathComponent("_posts")
-        filesFolder = siteFolder.fileURL.appendingPathComponent("_files")
-        draftsFolder = siteFolder.fileURL.appendingPathComponent("_drafts")
+        filesFolder = siteFolder.fileURL.appendingPathComponent("assets")
+    }
+
+    var webBase: URL {
+        // Assuming that you're also running jekyll in dev mode nearby. MarsEdit
+        // will need this running to fetch assets for preview.
+        URL(string: "http://localhost:4000/")!
     }
     
 }

--- a/Sources/jekyll-pub/XMLRPC/Protocols/MetaWeblog.swift
+++ b/Sources/jekyll-pub/XMLRPC/Protocols/MetaWeblog.swift
@@ -7,23 +7,24 @@
 
 import Foundation
 
+// https://codex.wordpress.org/XML-RPC_MetaWeblog_API
 enum MetaWeblog {
 
     struct GetCategories: XMLRPCMethod {
         typealias XMLRPCMethodResult = Array<JekyllCategory>
         static let methodCalls: Set<String> = ["metaWeblog.getCategories"]
-        
+
         let blogID: String
         let userName: String
         let password: String
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             blogID = try c.decode(String.self)
             userName = try c.decode(String.self)
             password = try c.decode(String.self)
         }
-        
+
         func execute(with site: JekyllSite) throws -> Array<JekyllCategory> {
             return site.allCategories()
         }
@@ -32,12 +33,12 @@ enum MetaWeblog {
     struct GetRecentPosts: XMLRPCMethod {
         typealias XMLRPCMethodResult = Array<JekyllPost>
         static let methodCalls: Set<String> = ["metaWeblog.getRecentPosts"]
-        
+
         let blogID: String
         let userName: String
         let password: String
         let count: Int
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             blogID = try c.decode(String.self)
@@ -49,7 +50,7 @@ enum MetaWeblog {
                 count = 10
             }
         }
-        
+
         func execute(with site: JekyllSite) throws -> Array<JekyllPost> {
             return site.recentPosts(count)
         }
@@ -58,13 +59,13 @@ enum MetaWeblog {
     struct NewPost: XMLRPCMethod {
         typealias XMLRPCMethodResult = String
         static let methodCalls: Set<String> = ["metaWeblog.newPost"]
-        
+
         let blogID: String
         let userName: String
         let password: String
         let content: JekyllPost
         let publish: Bool
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             blogID = try c.decode(String.self)
@@ -77,23 +78,23 @@ enum MetaWeblog {
                 publish = true
             }
         }
-        
+
         func execute(with site: JekyllSite) throws -> String {
-            return try site.newPost(content, publish: publish).id
+            return try site.newPost(content, publish: publish).id ?! CocoaError(CocoaError.fileNoSuchFile)
         }
-        
+
     }
 
     struct EditPost: XMLRPCMethod {
         typealias XMLRPCMethodResult = Bool
         static let methodCalls: Set<String> = ["metaWeblog.editPost"]
-        
+
         let blogID: String
         let userName: String
         let password: String
         let content: JekyllPost
         let publish: Bool
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             blogID = try c.decode(String.self)
@@ -106,19 +107,19 @@ enum MetaWeblog {
                 publish = true
             }
         }
-        
+
     }
 
     struct DeletePost: XMLRPCMethod {
         typealias XMLRPCMethodResult = Bool
         static let methodCalls: Set<String> = ["metaWeblog.deletePost", "blogger.deletePost"]
-        
+
         let blogID: String
         let postID: String
         let userName: String
         let password: String
         let publish: Bool
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             blogID = try c.decode(String.self)
@@ -127,7 +128,7 @@ enum MetaWeblog {
             password = try c.decode(String.self)
             publish = false
         }
-        
+
         func execute(with site: JekyllSite) throws -> Bool {
             return site.deletePost(postID)
         }
@@ -136,18 +137,18 @@ enum MetaWeblog {
     struct GetPost: XMLRPCMethod {
         typealias XMLRPCMethodResult = JekyllPost
         static let methodCalls: Set<String> = ["metaWeblog.getPost"]
-        
+
         let postID: String
         let userName: String
         let password: String
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             postID = try c.decode(String.self)
             userName = try c.decode(String.self)
             password = try c.decode(String.self)
         }
-        
+
         func execute(with site: JekyllSite) throws -> JekyllPost {
             return try site.getPost(postID)
         }
@@ -156,12 +157,12 @@ enum MetaWeblog {
     struct NewMediaObject: XMLRPCMethod {
         typealias XMLRPCMethodResult = JekyllMediaResult
         static let methodCalls: Set<String> = ["metaWeblog.newMediaObject"]
-        
+
         let blogID: String
         let userName: String
         let password: String
         let media: JekyllMedia
-        
+
         init(from decoder: Decoder) throws {
             var c = try decoder.unkeyedContainer()
             blogID = try c.decode(String.self)
@@ -169,7 +170,7 @@ enum MetaWeblog {
             password = try c.decode(String.self)
             media = try c.decode(JekyllMedia.self)
         }
-        
+
         func execute(with site: JekyllSite) throws -> JekyllMediaResult {
             return try site.saveMedia(media)
         }

--- a/Sources/jekyll-pub/XMLRPC/Protocols/MovableType.swift
+++ b/Sources/jekyll-pub/XMLRPC/Protocols/MovableType.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum MovableType {
+
+    struct GetCategories: XMLRPCMethod {
+        typealias XMLRPCMethodResult = Array<JekyllCategory>
+        static let methodCalls: Set<String> = ["mt.getCategoryList"]
+
+        let blogID: String
+        let userName: String
+        let password: String
+
+        init(from decoder: Decoder) throws {
+            var c = try decoder.unkeyedContainer()
+            blogID = try c.decode(String.self)
+            userName = try c.decode(String.self)
+            password = try c.decode(String.self)
+        }
+
+        func execute(with site: JekyllSite) throws -> Array<JekyllCategory> {
+            return site.allCategories()
+        }
+    }
+
+}


### PR DESCRIPTION
Strictly many of these changes are backwards-incompatible. I'm parsing dates differently, IDs are different (relative filenames, not absolute, and posts no longer have special case handling), minor changes like that. The stand-out difference is that the code currently acts as if there's a `_files` folder that means something specific, and I find nothing in the Jekyll docs that back this up at all. Files can be anywhere - I use `assets` so I hard-coded that for now. I suspect this is a minor breaking change as well because the media finder was _also_ broken and only returned directories. :-)

I suspect you're using an older version of ME than me, which is making different API calls. You have a whole fleshed-out metaweblog API handler that is totally unused other than a get categories list, for instance. Or you use some other client? Either way, it's hard to exercise the metaweblog code paths.

* Added MovableType handler to serve `mt.getCategoryList` which MarsEdit wants to call
* Media objects now serve a working (assuming server is running) http url to the asset
* Look for assets in /assets/ not /_files/
* Don't assume posts and drafts are in top-level folders
* Bind XMLRPC server to localhost explicitly for security reasons
* Missing server routes report notFound so MarsEdit doesn't throw up a login dialog
* Post publishedDate tries harder to parse the date, looks in more places, and falls back to filename
* Post slug is reported by API and can be set
* Report post edited date to the API
* Saving a post no longer completely replaces the YAML front-matter, just the fields we want to control
* Change how post and page IDs are calculated, and preserve them when the filenames change
* Order returned posts so that if the client fetches only the first page it gets the most important posts
